### PR TITLE
Fix nbunch string problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ docs/reference/invariants/generated
 # dist and build
 /dist
 /build
+
+# scratch folder
+/scratch

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 *A NetworkX extension for calculating graph invariants.*
 
 ### What is it?
-GrinPy is an extension for NetworkX used for calculating graph invariants for
+GrinPy is an extension for NetworkX used for calculating graph invariants of
 simple graphs.
 
-NP-hard invariants in the latest version include:
+NP-hard invariants in this version include:
 
 * Chromatic number
 * Clique number

--- a/grinpy/functions/degree.py
+++ b/grinpy/functions/degree.py
@@ -10,6 +10,7 @@
 """Assorted degree related graph utilities.
 """
 
+import collections
 from grinpy import degree, nodes, number_of_nodes
 from grinpy.functions.neighborhoods import closed_neighborhood, neighborhood
 
@@ -242,20 +243,22 @@ def number_of_max_degree_nodes(G):
     return number_of_nodes_of_degree_k(G, max_degree(G))
 
 def neighborhood_degree_list(G, nbunch):
-    """Return a list of the unique degrees of all neighbors of nodes in nbunch
+    """Return a list of the unique degrees of all neighbors of nodes in
+    `nbunch`.
 
     Parameters
     ----------
     G : NetworkX graph
         An undirected graph.
 
-    nbunch : a single node or iterable container of nodes
+    nbunch :
+        A single node or iterable container of nodes.
 
     Returns
     -------
     list
         A list of the degrees of all nodes in the neighborhood of the nodes
-        in nbunch.
+        in `nbunch`.
 
     See Also
     --------
@@ -268,24 +271,28 @@ def neighborhood_degree_list(G, nbunch):
     >>> gp.neighborhood_degree_list(G, 1)
     [1, 2]
     """
-    return list(set(degree(G, u) for u in neighborhood(G, nbunch)))
+    if isinstance(nodes, collections.abc.Iterable):
+        return list(set(degree(G, u) for u in set_neighborhood(G, nbunch)))
+    else:
+        return list(set(degree(G, u) for u in neighborhood(G, nbunch)))
 
 def closed_neighborhood_degree_list(G, nbunch):
     """Return a list of the unique degrees of all nodes in the closed
-    neighborhood of the nodes in nbunch.
+    neighborhood of the nodes in `nbunch`.
 
     Parameters
     ----------
     G : NetworkX graph
         An undirected graph.
 
-    nbunch : a single node or iterable container of nodes
+    nbunch :
+        A single node or iterable container of nodes.
 
     Returns
     -------
     list
         A list of the degrees of all nodes in the closed neighborhood of the
-        nodes in nbunch.
+        nodes in `nbunch`.
 
     See Also
     --------
@@ -298,7 +305,10 @@ def closed_neighborhood_degree_list(G, nbunch):
     >>> gp.closed_neighborhood_degree_list(G, 1)
     [1, 2, 2]
     """
-    return list(set(degree(G, u) for u in closed_neighborhood(G, nbunch)))
+    if isinstance(nodes, collections.abc.Iterable):
+        return list(set(degree(G, u) for u in set_closed_neighborhood(G, nbunch)))
+    else:
+        return list(set(degree(G, u) for u in closed_neighborhood(G, nbunch)))
 
 def is_regular(G):
     """ Return True if G is regular, and False otherwise.

--- a/grinpy/functions/neighborhoods.py
+++ b/grinpy/functions/neighborhoods.py
@@ -14,23 +14,26 @@ from grinpy import neighbors
 __all__ = ['neighborhood',
            'closed_neighborhood',
            'are_neighbors',
-           'common_neighbors'
+           'common_neighbors',
+           'set_neighborhood',
+           'set_closed_neighborhood'
           ]
 
-def neighborhood(G, nbunch):
-    """Return a list of all neighbors of the nodes in nbunch.
+def neighborhood(G, v):
+    """Return a list of all neighbors of v.
 
     Parameters
     ----------
     G : NetworkX graph
         An undirected graph.
 
-    nbunch : a single node or iterable container
+    v :
+        A node in G.
 
     Returns
     -------
     list
-        A list containing all nodes that are a neighbor of some node in nbunch.
+        A list containing all nodes that are a neighbor of v.
 
     See Also
     --------
@@ -42,34 +45,49 @@ def neighborhood(G, nbunch):
     >>> nx.neighborhood(G, 1)
     [0, 2]
     """
-    # check if nbunch is an iterable; if not, convert to a list
-    try:
-        _ = (v for v in nbunch)
-    except:
-        nbunch = [nbunch]
-    # loop through all nodes in nbunch and add their neighbors to the set of neighbors
-    N = set()
-    for v in nbunch:
-        N |= set(neighbors(G, v))
-    return list(N)
+    return list(neighbors(G, v))
 
-def closed_neighborhood(G, nbunch):
-    """Return a list of all neighbors of the nodes in nbunch, including the
-    nodes in nbunch.
+def set_neighborhood(G, nodes):
+    """Return a list of all neighbors of every node in nodes.
 
     Parameters
     ----------
     G : NetworkX graph
         An undirected graph.
 
-    nbunch :
-        A single node or iterable container
+    nodes :
+        An interable container of nodes in G.
 
     Returns
     -------
     list
-        A list containing all nodes that are a neighbor of some node in nbunch
-        together with all nodes in nbunch.
+        A list containing all nodes that are a neighbor of some node in nodes.
+
+    See Also
+    --------
+    set_closed_neighborhood
+    """
+    # TODO: write unit test
+    N = set()
+    for n in nodes:
+        N |= set(neighborhood(G, n))
+    return list(N)
+
+def closed_neighborhood(G, v):
+    """Return a list with v and of all neighbors of v.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+
+    v :
+        A node in G.
+
+    Returns
+    -------
+    list
+        A list containing v and all nodes that are a neighbor of v.
 
     See Also
     --------
@@ -81,16 +99,34 @@ def closed_neighborhood(G, nbunch):
     >>> nx.closed_neighborhood(G, 1)
     [0, 1, 2]
     """
-    # check if nbunch is an iterable; if not, convert to a list
-    try:
-        _ = (v for v in nbunch)
-    except:
-        nbunch = [nbunch]
-    N = set(neighborhood(G, nbunch)).union(nbunch)
-    return list(N)
+    return list(set(neighborhood(G, v)).union([v]))
 
-def are_neighbors(G, v, nbunch):
-    """Returns true if v is adjacent to any of the nodes in nbunch. Otherwise,
+def set_closed_neighborhood(G, nodes):
+    """Return a list containing every node in nodes all neighbors their neighbors.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected graph.
+
+    nodes :
+        An interable container of nodes in G.
+
+    Returns
+    -------
+    list
+        A list containing every node in nodes and all nodes of their neighbors.
+
+    See Also
+    --------
+    set_neighborhood
+    """
+    # TODO: write unit test
+    N = set(set_neighborhood(G, nodes)).union(nodes)
+    return(list(N))
+
+def are_neighbors(G, u, v):
+    """Returns true if u is adjacent to v. Otherwise,
     returns false.
 
     Parameters
@@ -98,20 +134,17 @@ def are_neighbors(G, v, nbunch):
     G : NetworkX graph
         An undirected graph.
 
+    u : node
+        A node in the graph.
+
     v : node
         A node in the graph.
 
-    nbunch :
-        A single node or iterable container
 
     Returns
     -------
     bool
-        If nbunch in a single node, True if v in a neighbor that node and False
-        otherwise.
-
-        If nbunch is an interable, True if v is a neighbor of some node in
-        nbunch and False otherwise.
+        True if u is a neighbor of v in G, False otherwise.
 
 
     Examples
@@ -121,13 +154,11 @@ def are_neighbors(G, v, nbunch):
     True
     >>> nx.are_neighbors(G, 1, 2)
     False
-    >>> nx.are_neighbors(G, 1, [0, 2])
-    True
     """
-    return v in neighborhood(G, nbunch)
+    return u in neighborhood(G, v)
 
-def common_neighbors(G, nbunch):
-    """Returns a list of all nodes in G that are adjacent to every node in `nbunch`.
+def common_neighbors(G, nodes):
+    """Returns a list of all nodes in G that are adjacent to every node in `nodes`.
 
     Parameters
     ----------
@@ -143,12 +174,7 @@ def common_neighbors(G, nbunch):
         All nodes adjacent to every node in nbunch. If nbunch contains only a
         single node, that nodes neighborhood is returned.
     """
-    # check if nbunch is an iterable; if not, convert to a list
-    try:
-        _ = (v for v in nbunch)
-    except:
-        nbunch = [nbunch]
-    S = set(neighborhood(G, nbunch[0]))
-    for node in nbunch:
-        S = S.intersection(set(neighborhood(G, node)))
+    S = set(neighborhood(G, nodes[0]))
+    for n in nodes:
+        S = S.intersection(set(neighborhood(G, n)))
     return list(S)

--- a/grinpy/invariants/chromatic.py
+++ b/grinpy/invariants/chromatic.py
@@ -9,7 +9,7 @@
 #          Randy Davila <davilar@uhd.edu>
 """Functions for computing the chromatic number of a graph."""
 
-from grinpy import nodes
+from grinpy import nodes, is_connected
 from grinpy.functions.graph_operations import contract_nodes
 from grinpy.functions.neighborhoods import are_neighbors, common_neighbors
 from grinpy.functions.structural_properties import is_complete_graph
@@ -43,11 +43,13 @@ def chromatic_number(G):
     finite, connected graph, *arXiv preprint
     arXiv:1309.3642*, (2013)
     """
+    if not is_connected(G): raise TypeError('Invalid graph: not connected')
     if is_complete_graph(G): return G.order()
     # get list of pairs of non neighbors in G
     N = [list(p) for p in pairs_of_nodes(G) if not are_neighbors(G, p[0], p[1])]
     # get a pair of non neighbors who have the most common neighbors
-    P = N[np.argmax(list(map(lambda p: len(common_neighbors(G, p)), N)))]
+    num_common_neighbors = list(map(lambda p: len(common_neighbors(G, p)), N))
+    P = N[np.argmax(num_common_neighbors)]
     # Collapse the nodes in P and repeat the above process
     H = G.copy()
     contract_nodes(H, P)

--- a/grinpy/invariants/independence.py
+++ b/grinpy/invariants/independence.py
@@ -11,7 +11,7 @@
 
 # imports
 from itertools import combinations
-from grinpy import neighborhood, nodes, number_of_edges, number_of_nodes
+from grinpy import neighborhood, nodes, number_of_edges, number_of_nodes, set_neighborhood
 from grinpy.invariants.dsi import annihilation_number
 
 __all__ = ['is_independent_set',
@@ -23,8 +23,8 @@ __all__ = ['is_independent_set',
            ]
 
 # methods
-def is_independent_set(G, nbunch):
-    """Return whether or not the nodes in nbunch comprise an independent set.
+def is_independent_set(G, nodes):
+    """Return whether or not the *nodes* comprises an independent set.
 
     An set *S* of nodes in *G* is called an *independent set* if no two nodes in
     S are neighbors of one another.
@@ -34,29 +34,24 @@ def is_independent_set(G, nbunch):
     G : NetworkX graph
         An undirected graph.
 
-    nbunch :
-        A single node or iterable container or nodes.
+    nodes : list, set
+        An iterable container of nodes in G.
 
     Returns
     -------
     bool
-        True if the nodes in nbunch comprise an independent set, False
+        True if the the nodes in *nodes* comprise an independent set, False
         otherwise.
 
     See Also
     --------
     is_k_independent_set
     """
-    # check if nbunch is an iterable; if not, convert to a list
-    try:
-        _ = (v for v in nbunch)
-    except:
-        nbunch = [nbunch]
-    S = set(n for n in nbunch if n in G)
-    return set(neighborhood(G, S)).intersection(S) == set()
+    S = set(n for n in nodes if n in G)
+    return set(set_neighborhood(G, S)).intersection(S) == set()
 
-def is_k_independent_set(G, nbunch, k):
-    """Return whether or not the nodes in nbunch comprise an a k-independent
+def is_k_independent_set(G, nodes, k):
+    """Return whether or not the nodes in *nodes* comprise an a k-independent
     set.
 
     A set *S* of nodes in *G* is called a *k-independent set* it every node
@@ -68,8 +63,8 @@ def is_k_independent_set(G, nbunch, k):
     G : NetworkX graph
         An undirected graph.
 
-    nbunch :
-        A single node or iterable container or nodes.
+    nodes : list, set
+        An iterable container of nodes in G.
 
     k : int
         A positive integer.
@@ -77,24 +72,20 @@ def is_k_independent_set(G, nbunch, k):
     Returns
     -------
     bool
-        True if the nodes in nbunch comprise a k-independent set, False
+        True if the nodes in *nodes* comprise a k-independent set, False
         otherwise.
 
     See Also
     --------
     is_independent_set
     """
-    # check if nbunch is an iterable; if not, convert to a list
-    try:
-        _ = (v for v in nbunch)
-    except:
-        nbunch = [nbunch]
     if k == 1:
-        return is_independent_set(G, nbunch)
+        return is_independent_set(G, nodes)
     else:
-        for v in nbunch:
+        S = set(n for n in nodes if n in G)
+        for v in S:
             N = set(neighborhood(G, v))
-            if len(N.intersection(nbunch)) >= k:
+            if len(N.intersection(S)) >= k:
                 return False
         return True
 

--- a/grinpy/invariants/power_domination.py
+++ b/grinpy/invariants/power_domination.py
@@ -9,7 +9,7 @@
 #          Randy Davila <davilar@uhd.edu>
 """Functions for computing power domination related invariants of a graph."""
 
-from grinpy import closed_neighborhood, nodes, number_of_nodes
+from grinpy import set_closed_neighborhood
 from grinpy.invariants.zero_forcing import is_zero_forcing_set, is_k_forcing_set
 from itertools import combinations
 
@@ -21,8 +21,8 @@ __all__ = ['is_k_power_dominating_set',
            'power_domination_number'
            ]
 
-def is_k_power_dominating_set(G, nbunch, k):
-    """Return whether or not the nodes in nbunch comprise a k-power dominating
+def is_k_power_dominating_set(G, nodes, k):
+    """Return whether or not the nodes in `nodes` comprise a k-power dominating
     set.
 
     Parameters
@@ -30,8 +30,8 @@ def is_k_power_dominating_set(G, nbunch, k):
     G : NetworkX graph
         An undirected graph.
 
-    nbunch :
-        A single node or iterable container or nodes.
+    nodes : list, set
+        An iterable container of nodes in G.
 
     k : int
         A positive integer.
@@ -39,15 +39,10 @@ def is_k_power_dominating_set(G, nbunch, k):
     Returns
     -------
     boolean
-        True if the nodes in nbunch comprise a k-power dominating set, False
+        True if the nodes in `nodes` comprise a k-power dominating set, False
         otherwise.
     """
-    # check if nbunch is an iterable; if not, convert to a list
-    try:
-        _ = (v for v in nbunch)
-    except:
-        nbunch = [nbunch]
-    return is_k_forcing_set(G, closed_neighborhood(G, nbunch), k)
+    return is_k_forcing_set(G, set_closed_neighborhood(G, nodes), k)
 
 def min_k_power_dominating_set(G, k):
     """Return a smallest k-power dominating set of nodes in *G*.
@@ -64,8 +59,8 @@ def min_k_power_dominating_set(G, k):
     list
         A list of nodes in a smallest k-power dominating set in *G*.
     """
-    for i in range(1, number_of_nodes(G) + 1):
-        for S in combinations(nodes(G), i):
+    for i in range(1, G.order() + 1):
+        for S in combinations(G.nodes(), i):
             if is_k_power_dominating_set(G, S, k):
                 return list(S)
 
@@ -84,8 +79,8 @@ def k_power_domination_number(G, k):
     """
     return len(min_k_power_dominating_set(G, k))
 
-def is_power_dominating_set(G, nbunch):
-    """Return whether or not the nodes in nbunch comprise a power dominating
+def is_power_dominating_set(G, nodes):
+    """Return whether or not the nodes in `nodes` comprise a power dominating
     set.
 
     Parameters
@@ -93,16 +88,16 @@ def is_power_dominating_set(G, nbunch):
     G : NetworkX graph
         An undirected graph.
 
-    nbunch :
-        A single node or iterable container or nodes.
+    nodes : list, set
+        An iterable container of nodes in G.
 
     Returns
     -------
     boolean
-        True if the nodes in nbunch comprise a power dominating set, False
+        True if the nodes in `nodes` comprise a power dominating set, False
         otherwise.
     """
-    return is_k_power_dominating_set(G, nbunch, 1)
+    return is_k_power_dominating_set(G, nodes, 1)
 
 def min_power_dominating_set(G):
     """Return a smallest power dominating set of nodes in *G*.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ sys.path.insert(1, wd)
 name = 'grinpy'
 author = 'David Amos, Randy Davila'
 email = 'amosd2@tamu.edu, davilar@uhd.edu'
-version = '0.2.0a1'
+version = '0.2.0a2'
 classifiers = [
     'Development Status :: 2 - Pre-Alpha',
     'Intended Audience :: Science/Research',

--- a/tests/test_domination.py
+++ b/tests/test_domination.py
@@ -5,12 +5,12 @@ class TestDomination():
     def test_non_integral_value_for_k_raises_error_in_is_k_dom_set(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
             G = gp.star_graph(2)
-            gp.is_k_dominating_set(G, 0, 1.5)
+            gp.is_k_dominating_set(G, [0], 1.5)
 
     def test_0_value_for_k_raises_error_in_is_k_dom_set(self):
         with pytest.raises(ValueError, message="Excepted non-positive value for k to throw ValueError."):
             G = gp.star_graph(2)
-            gp.is_k_dominating_set(G, 0, 0)
+            gp.is_k_dominating_set(G, [0], 0)
 
     def test_non_int_value_for_k_raises_error_in_min_k_dom_set(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
@@ -34,27 +34,27 @@ class TestDomination():
 
     def test_integral_float_for_k_works(self):
         G = gp.star_graph(2)
-        assert(gp.is_k_dominating_set(G, 0, 1.0) == True)
+        assert(gp.is_k_dominating_set(G, [0], 1.0) == True)
 
     def test_max_degree_vertex_is_dominating_set_of_star(self):
         for i in range(1, 9):
             G = gp.star_graph(i)
-            assert(gp.is_k_dominating_set(G, 0, 1) == True)
+            assert(gp.is_k_dominating_set(G, [0], 1) == True)
 
     def test_min_degree_vertex_is_not_dominating_set_of_star(self):
         for i in range(2, 9):
             G = gp.star_graph(i)
-            assert(gp.is_k_dominating_set(G, 1, 1) == False)
+            assert(gp.is_k_dominating_set(G, [1], 1) == False)
 
     def test_dominating_set_with_nodes_not_in_graph(self):
         G = gp.star_graph(3)
-        assert(gp.is_k_dominating_set(G, 4, 1) == False)
+        assert(gp.is_k_dominating_set(G, [4], 1) == False)
         assert(gp.is_k_dominating_set(G, [0, 4], 1) == True)
 
     def test_max_degree_vertex_is_not_2_dominating_set_of_star(self):
         for i in range(1, 9):
             G = gp.star_graph(i)
-            assert(gp.is_k_dominating_set(G, 0, 2) == False)
+            assert(gp.is_k_dominating_set(G, [0], 2) == False)
 
     def test_min_degree_vertices_are_2_dominating_set_of_star(self):
         for i in range(2, 9):
@@ -65,13 +65,13 @@ class TestDomination():
     def test_2_dominating_set_with_nodes_not_in_graph(self):
         G = gp.star_graph(3)
         nodes = [1, 2, 3, 4]
-        assert(gp.is_k_dominating_set(G, 4, 1) == False)
+        assert(gp.is_k_dominating_set(G, [4], 1) == False)
         assert(gp.is_k_dominating_set(G, nodes, 1) == True)
 
     def test_no_single_node_is_total_dominating_set_of_star(self):
         G = gp.star_graph(3)
         for v in gp.nodes(G):
-            assert(gp.is_total_dominating_set(G, v) == False)
+            assert(gp.is_total_dominating_set(G, [v]) == False)
 
     def test_adjacent_vertices_are_total_dominating_set_of_star(self):
         G = gp.star_graph(3)
@@ -89,7 +89,7 @@ class TestDomination():
 
     def test_center_vertex_of_star_is_connected_dominating_set(self):
         G = gp.star_graph(3)
-        assert(gp.is_connected_dominating_set(G, 0) == True)
+        assert(gp.is_connected_dominating_set(G, [0]) == True)
 
     def test_leaves_of_star_are_not_connected_dominating_set(self):
         G = gp.star_graph(3)
@@ -130,12 +130,12 @@ class TestDomination():
     def test_non_int_value_for_k_raises_error_in_connected_k_dom_set(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
             G = gp.star_graph(2)
-            gp.is_connected_k_dominating_set(G, 0, 1.5)
+            gp.is_connected_k_dominating_set(G, [0], 1.5)
 
     def test_0_value_for_k_raises_error_in_connected_k_dom_set(self):
         with pytest.raises(ValueError, message="Excepted non-positive value for k to throw ValueError."):
             G = gp.star_graph(2)
-            gp.is_connected_k_dominating_set(G, 0, 0)
+            gp.is_connected_k_dominating_set(G, [0], 0)
 
     def test_non_int_value_for_k_raises_error_in_min_connected_k_dom_set(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
@@ -160,12 +160,12 @@ class TestDomination():
     def test_non_int_value_for_k_raises_error_in_ind_k_dom_set(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
             G = gp.star_graph(2)
-            gp.is_independent_k_dominating_set(G, 0, 1.5)
+            gp.is_independent_k_dominating_set(G, [0], 1.5)
 
     def test_0_value_for_k_raises_error_in_ind_k_dom_set(self):
         with pytest.raises(ValueError, message="Excepted non-positive value for k to throw ValueError."):
             G = gp.star_graph(2)
-            gp.is_independent_k_dominating_set(G, 0, 0)
+            gp.is_independent_k_dominating_set(G, [0], 0)
 
     def test_non_int_value_for_k_raises_error_in_min_ind_k_dom_set(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):

--- a/tests/test_independence.py
+++ b/tests/test_independence.py
@@ -3,11 +3,11 @@ from grinpy import grinpy as gp
 class TestIndependence():
     def test_single_vertex_is_independent_set(self):
         G = gp.trivial_graph()
-        assert(gp.is_independent_set(G, 0) == True)
+        assert(gp.is_independent_set(G, [0]) == True)
 
     def test_single_vertex_is_2_independent_set(self):
         G = gp.trivial_graph()
-        assert(gp.is_k_independent_set(G, 0, 2) == True)
+        assert(gp.is_k_independent_set(G, [0], 2) == True)
 
     def test_set_of_leaves_of_star_is_independent_set(self):
         for i in range(2, 10):

--- a/tests/test_neighborhoods.py
+++ b/tests/test_neighborhoods.py
@@ -46,12 +46,8 @@ class TestNeighborhoods():
         G = self.G
         t1 = gp.are_neighbors(G, 0, 1)
         t2 = gp.are_neighbors(G, 0, 4)
-        t3 = gp.are_neighbors(G, 0, [1, 4])
-        t4 = gp.are_neighbors(G, 0, [4, 5])
         assert(t1 == True)
         assert(t2 == False)
-        assert(t3 == True)
-        assert(t4 == False)
 
     def test_common_neighbors_of_pair_of_nodes_in_K3_is_third_node(self):
         G = gp.complete_graph(3)
@@ -59,4 +55,4 @@ class TestNeighborhoods():
 
     def test_common_neighbors_of_single_node_in_K3_is_other_two_nodes(self):
         G = gp.complete_graph(3)
-        assert(gp.common_neighbors(G, 0) == [1, 2])
+        assert(gp.common_neighbors(G, [0]) == [1, 2])

--- a/tests/test_power_domination.py
+++ b/tests/test_power_domination.py
@@ -5,13 +5,13 @@ class TestPowerDomination():
     def test_center_node_is_power_dominating_set_of_star(self):
         for i in range(1, 11):
             G = gp.star_graph(i)
-            assert(gp.is_power_dominating_set(G, 0) == True)
+            assert(gp.is_power_dominating_set(G, [0]) == True)
 
     def test_leaf_is_not_power_dominating_set_of_star(self):
         for i in range(3, 13):
             G = gp.star_graph(i)
             for j in range(1, i+1):
-                assert(gp.is_power_dominating_set(G, j) == False)
+                assert(gp.is_power_dominating_set(G, [j]) == False)
 
     def test_empty_set_is_not_power_dominating_set_of_trivial_graph(self):
         G = gp.trivial_graph()

--- a/tests/test_zero_forcing.py
+++ b/tests/test_zero_forcing.py
@@ -5,24 +5,24 @@ class TestZeroForcing():
     def test_non_integral_value_for_k_raises_TypeError_in_is_k_forcing(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
             G = gp.star_graph(2)
-            gp.is_k_forcing_vertex(G, 1, 1, 1.5)
+            gp.is_k_forcing_vertex(G, 1, [1], 1.5)
 
     def test_0_value_for_k_raises_ValueError_in_is_k_forcing(self):
         with pytest.raises(ValueError, message="Excepted non-positive value for k to throw ValueError."):
             G = gp.star_graph(2)
-            gp.is_k_forcing_vertex(G, 1, 1, 0)
+            gp.is_k_forcing_vertex(G, 1, [1], 0)
 
     def test_integral_float_for_k_works(self):
         G = gp.star_graph(2)
-        assert(gp.is_k_forcing_vertex(G, 1, 1, 1.0) == True)
+        assert(gp.is_k_forcing_vertex(G, 1, [1], 1.0) == True)
 
     def test_leaf_is_zero_forcing_vertex_for_star(self):
         G = gp.star_graph(2)
-        assert(gp.is_zero_forcing_vertex(G, 1, 1) == True)
+        assert(gp.is_zero_forcing_vertex(G, 1, [1]) == True)
 
     def test_center_is_not_zero_forcing_vertex_for_star(self):
         G = gp.star_graph(2)
-        assert(gp.is_zero_forcing_vertex(G, 0, 0) == False)
+        assert(gp.is_zero_forcing_vertex(G, 0, [0]) == False)
 
     def test_no_vertex_is_zero_forcing_vertex_for_empty_set(self):
         G = gp.star_graph(2)
@@ -32,19 +32,19 @@ class TestZeroForcing():
 
     def test_center_of_S3_is_3_forcing_vertex(self):
         G = gp.star_graph(3)
-        assert(gp.is_k_forcing_vertex(G, 0, 0, 3) == True)
+        assert(gp.is_k_forcing_vertex(G, 0, [0], 3) == True)
 
     def test_center_of_S3_is_not_2_forcing_vertex(self):
         G = gp.star_graph(3)
-        assert(gp.is_k_forcing_vertex(G, 0, 0, 2) == False)
+        assert(gp.is_k_forcing_vertex(G, 0, [0], 2) == False)
 
     def test_leaf_of_star_is_zero_forcing_active_set(self):
         G = gp.star_graph(2)
-        assert(gp.is_zero_forcing_active_set(G, 1) == True)
+        assert(gp.is_zero_forcing_active_set(G, [1]) == True)
 
     def test_center_of_star_is_not_zero_forcing_active_set(self):
         G = gp.star_graph(2)
-        assert(gp.is_zero_forcing_active_set(G, 0) == False)
+        assert(gp.is_zero_forcing_active_set(G, [0]) == False)
 
     def test_empy_set_is_not_zero_forcing_active_set(self):
         G = gp.star_graph(2)
@@ -52,17 +52,17 @@ class TestZeroForcing():
 
     def test_leaf_is_zero_forcing_set_of_path(self):
         G = gp.path_graph(3)
-        assert(gp.is_zero_forcing_set(G, 0) == True)
+        assert(gp.is_zero_forcing_set(G, [0]) == True)
 
     def test_leaf_is_not_zero_forcing_set_of_S3(self):
         G = gp.star_graph(3)
-        assert(gp.is_zero_forcing_set(G, 1) == False)
+        assert(gp.is_zero_forcing_set(G, [1]) == False)
 
     def test_leaf_is_max_degree_minus_one_forcing_set_for_star(self):
         for i in range(3, 13):
             G = gp.star_graph(i)
             D = gp.max_degree(G)
-            assert(gp.is_k_forcing_set(G, 1, D-1) == True)
+            assert(gp.is_k_forcing_set(G, [1], D-1) == True)
 
     def test_zero_forcing_number_of_star_is_order_minus_2(self):
         for i in range(2, 12):
@@ -79,7 +79,7 @@ class TestZeroForcing():
 
     def test_leaf_is_not_total_forcing_set_of_path(self):
         G = gp.path_graph(3)
-        assert(gp.is_total_zero_forcing_set(G, 0) == False)
+        assert(gp.is_total_zero_forcing_set(G, [0]) == False)
 
     def test_pair_of_adjacent_nodes_is_total_forcing_set_of_path(self):
         G = gp.path_graph(6)
@@ -98,12 +98,12 @@ class TestZeroForcing():
     def test_non_int_value_for_k_raises_error_in_is_connected_k_forcing(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
             G = gp.star_graph(2)
-            gp.is_connected_k_forcing_set(G, 0, 1.5)
+            gp.is_connected_k_forcing_set(G, [0], 1.5)
 
     def test_0_value_for_k_raises_error_in_is_connected_k_forcing(self):
         with pytest.raises(ValueError, message="Excepted non-positive value for k to throw ValueError."):
             G = gp.star_graph(2)
-            gp.is_connected_k_forcing_set(G, 0, 0)
+            gp.is_connected_k_forcing_set(G, [0], 0)
 
     def test_non_int_value_for_k_raises_error_in_min_connected_k_forcing(self):
         with pytest.raises(TypeError, message="Excepted non-integral value for k to throw TypeError."):
@@ -131,7 +131,7 @@ class TestZeroForcing():
 
     def test_endpoint_is_connected_forcing_set_of_path(self):
         G = gp.path_graph(2)
-        assert(gp.is_connected_zero_forcing_set(G, 0))
+        assert(gp.is_connected_zero_forcing_set(G, [0]))
 
     def test_connected_zero_forcing_num_of_disconnected_graph_is_None(self):
         G = gp.empty_graph(5)


### PR DESCRIPTION
This update fixes a major issue when node names are strings. In this case, several methods with the `nbunch` argument were iterating through the strings and treating each character as a node. For example, if a node named `'10'` were passed in the argument, the method would treat this as two nodes, `'1'` and `'0'`.

The solution was to require the `nbunch` argument to be a container of nodes (such as a list or a set). Incidentally, this still allows strings to be passed as the argument, but the user now understands that a singleton cannot be passed, only a container.