### PR TITLE
Add triameter invariant

### DIFF
--- a/docs/reference/functions/distance.rst
+++ b/docs/reference/functions/distance.rst
@@ -1,0 +1,10 @@
+********
+Distance
+********
+
+.. automodule:: grinpy.functions.distance
+
+.. autosummary::
+  :toctree: generated/
+
+  distance

--- a/docs/reference/functions/generated/grinpy.functions.distance.distance.rst
+++ b/docs/reference/functions/generated/grinpy.functions.distance.distance.rst
@@ -1,0 +1,6 @@
+grinpy.functions.distance.distance
+==================================
+
+.. currentmodule:: grinpy.functions.distance
+
+.. autofunction:: distance

--- a/docs/reference/functions/index.rst
+++ b/docs/reference/functions/index.rst
@@ -10,4 +10,5 @@ Functions
    :maxdepth: 2
 
    degree
+   distance
    neighborhoods

--- a/docs/reference/invariants/distance_measures.rst
+++ b/docs/reference/invariants/distance_measures.rst
@@ -1,0 +1,10 @@
+*****************
+Distance Measures
+*****************
+
+.. automodule:: grinpy.invariants.distance_measures
+
+.. autosummary::
+  :toctree: generated/
+
+  triameter

--- a/docs/reference/invariants/generated/grinpy.invariants.distance_measures.triameter.rst
+++ b/docs/reference/invariants/generated/grinpy.invariants.distance_measures.triameter.rst
@@ -1,0 +1,6 @@
+grinpy.invariants.distance\_measures.triameter
+==============================================
+
+.. currentmodule:: grinpy.invariants.distance_measures
+
+.. autofunction:: triameter

--- a/docs/reference/invariants/index.rst
+++ b/docs/reference/invariants/index.rst
@@ -12,6 +12,7 @@ Invariants
    chromatic
    clique
    disparity
+   distance_measures
    domination
    dsi
    independence

--- a/grinpy/functions/__init__.py
+++ b/grinpy/functions/__init__.py
@@ -1,4 +1,5 @@
 from grinpy.functions.degree import *  # noqa
+from grinpy.functions.distance import *  # noqa
 from grinpy.functions.graph_operations import *  # noqa
 from grinpy.functions.neighborhoods import *  # noqa
 from grinpy.functions.structural_properties import *  # noqa
@@ -6,6 +7,7 @@ from grinpy.functions.structural_properties import *  # noqa
 # Make certain subpackages available to the user as direct imports from
 # the `grinpy` namespace.
 import grinpy.functions.degree
+import grinpy.functions.distance
 import grinpy.functions.graph_operations
 import grinpy.functions.neighborhoods
 import grinpy.functions.structural_properties  # noqa

--- a/grinpy/functions/distance.py
+++ b/grinpy/functions/distance.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2017---2019 by
+#    David Amos <somacdivad@gmail.com>
+#    Randy Davila <davilar@uhd.edu>
+#    BSD license.
+#
+# Authors: David Amos <somacdivad@gmail.com>
+#          Randy Davila <davilar@uhd.edu>
+"""Functions for computing distances in graphs"""
+
+import networkx as nx
+
+
+def distance(G, source, target):
+    r"""Return the distance in ``G`` between the ``source`` and ``target`` nodes.
+
+    The *distance* between two nodes in a graph is the length of a
+    shortest path between the nodes.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected connected graph with order at least 3.
+
+    source : node in G
+
+    target : node in G
+
+    Returns
+    -------
+    int
+        The distance between ``source`` and ``target`` in ``G``
+    """
+    return nx.shortest_path_length(G, source=source, target=target)

--- a/grinpy/invariants/__init__.py
+++ b/grinpy/invariants/__init__.py
@@ -1,6 +1,7 @@
 from grinpy.invariants.chromatic import *  # noqa
 from grinpy.invariants.clique import *  # noqa
 from grinpy.invariants.disparity import *  # noqa
+from grinpy.invariants.distance_measures import *  # noqa
 from grinpy.invariants.domination import *  # noqa
 from grinpy.invariants.dsi import *  # noqa
 from grinpy.invariants.independence import *  # noqa
@@ -15,6 +16,7 @@ from grinpy.invariants.zero_forcing import *  # noqa
 import grinpy.invariants.chromatic  # noqa
 import grinpy.invariants.clique  # noqa
 import grinpy.invariants.disparity  # noqa
+import grinpy.invariants.distance_measures  # noqa
 import grinpy.invariants.domination  # noqa
 import grinpy.invariants.dsi  # noqa
 import grinpy.invariants.independence  # noqa

--- a/grinpy/invariants/distance_measures.py
+++ b/grinpy/invariants/distance_measures.py
@@ -39,16 +39,8 @@ def triameter(G):
     https://arxiv.org/pdf/1804.01088.pdf
     """
     _distance = functools.partial(distance, G)
-    _combinations = itertools.combinations
     distance_sums = (
-        sum((_distance(*pair) for pair in _combinations(nodes, 2))) for nodes in _combinations(G.nodes(), 3)
+        sum((_distance(*pair) for pair in itertools.combinations(nodes, 2)))
+        for nodes in itertools.combinations(G.nodes(), 3)
     )
     return max(distance_sums)
-    # d = []
-    # for s in itertools.combinations(G.nodes(), 3):
-    #     x1 = distance(G, source=s[0], target=s[1])
-    #     x2 = distance(G, source=s[1], target=s[2])
-    #     x3 = distance(G, source=s[0], target=s[2])
-    #     d.append(x1 + x2 + x3)
-
-    # return max(d)

--- a/grinpy/invariants/distance_measures.py
+++ b/grinpy/invariants/distance_measures.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2017---2019 by
+#    David Amos <somacdivad@gmail.com>
+#    Randy Davila <davilar@uhd.edu>
+#    BSD license.
+#
+# Authors: David Amos <somacdivad@gmail.com>
+#          Randy Davila <davilar@uhd.edu>
+"""Functions for computing distance-related invariants in a graph"""
+
+import itertools
+import functools
+
+from grinpy.functions.distance import distance
+
+
+def triameter(G):
+    r"""Returns the triameter of the graph G with at least 3 nodes.
+
+    The *triameter* of a connected graph G with vertex set *V* is defined as the
+    following maximum value
+    .. math::
+        \max\{d(v,w) + d(w,z) + d(v,z): v,w,z \in V: \}
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected connected graph with order at least 3.
+
+    Returns
+    -------
+    int
+        The triameter of the graph G.
+
+    References
+    ----------
+    A. Das, The triameter of graphs, ArXiv preprint arXiv:1804.01088, 2018.
+    https://arxiv.org/pdf/1804.01088.pdf
+    """
+    _distance = functools.partial(distance, G)
+    _combinations = itertools.combinations
+    distance_sums = (
+        sum((_distance(*pair) for pair in _combinations(nodes, 2))) for nodes in _combinations(G.nodes(), 3)
+    )
+    return max(distance_sums)
+    # d = []
+    # for s in itertools.combinations(G.nodes(), 3):
+    #     x1 = distance(G, source=s[0], target=s[1])
+    #     x2 = distance(G, source=s[1], target=s[2])
+    #     x3 = distance(G, source=s[0], target=s[2])
+    #     d.append(x1 + x2 + x3)
+
+    # return max(d)

--- a/tests/test_distance_measures.py
+++ b/tests/test_distance_measures.py
@@ -11,8 +11,8 @@ class TestDistanceMeasures:
             (gp.cycle_graph(4), 4),
             (gp.cycle_graph(5), 5),
             (gp.path_graph(3), 4),
-            (gp.path_graph(4), 5),
-            (gp.path_graph(5), 6),
+            (gp.path_graph(4), 6),
+            (gp.path_graph(5), 8),
         ),
     )
     def test_triameter(self, graph, expected_value):

--- a/tests/test_distance_measures.py
+++ b/tests/test_distance_measures.py
@@ -1,0 +1,20 @@
+import pytest
+
+import grinpy as gp
+
+
+class TestDistanceMeasures:
+    @pytest.mark.parametrize(
+        "graph, expected_value",
+        (
+            (gp.cycle_graph(3), 3),
+            (gp.cycle_graph(4), 4),
+            (gp.cycle_graph(5), 5),
+            (gp.path_graph(3), 4),
+            (gp.path_graph(4), 5),
+            (gp.path_graph(5), 6),
+        ),
+    )
+    def test_triameter(self, graph, expected_value):
+        """Ensure triameter returns the expected value for a given graph"""
+        assert gp.triameter(graph) == expected_value

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,3 +1,5 @@
+import pytest
+
 import grinpy as gp
 
 
@@ -11,3 +13,17 @@ class TestFunctions:
     def test_elimination_sequence_of_complete_graph(self):
         G = gp.complete_graph(5)
         assert gp.elimination_sequence(G) == [4, 3, 2, 1, 0]
+
+    @pytest.mark.parametrize(
+        "graph, source, target, expected_value",
+        (
+            (gp.path_graph(5), 0, 4, 4),
+            (gp.path_graph(5), 1, 4, 3),
+            (gp.path_graph(5), 2, 4, 2),
+            (gp.path_graph(5), 3, 4, 1),
+            (gp.path_graph(5), 4, 4, 0),
+        ),
+    )
+    def test_distance(self, graph, source, target, expected_value):
+        """Ensure that distance returns the expected value for a given graph"""
+        assert gp.distance(graph, source, target) == expected_value


### PR DESCRIPTION
This PR adds support for the *triameter* graph invariant.

A `distance()` function was added to `grinpy.functions.distance`. This function is a wrapper for the `networkx.shortest_path_length` function.