### PR TITLE
Set-up Read The Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
--r ../requirements/doc.txt
+nb2plots==0.6
+sphinx==2.0.1
+sphinx_rtd_theme==0.4.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,13 +3,10 @@ bumpversion==0.5.3
 codecov==2.0.15
 coverage==4.5.3
 flake8==3.7.7
-nb2plots==0.6
 pydocstyle==3.0.0
 pytest==4.5.0
 pytest-cov==2.7.1
 pytest-runner==5.1
-sphinx==2.0.1
-sphinx_rtd_theme==0.4.3
 tox==3.12.1
 twine==1.13.0
 wheel==0.33.4


### PR DESCRIPTION
This PR adds a `.readthedocs.yml` configuration file for Read The Docs, and also fixes the RTD build issue where no `requirements.txt` could be found.